### PR TITLE
feature: export tested proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ No more slow or clunky testing tools. Get instant feedback with a detailed, real
 - ✨ **Smart & Interactive UI:**
   - **Auto-Parsing:** Paste your list in almost any common format (`host:port:user:pass`, `user:pass@host:port`, etc.) and the app handles it.
   - **Easy Actions:** Copy proxy strings/IPs, view detailed breakdowns, and manage your results with a single click.
+  - **Export results:** After a run finishes, use **Export** next to the toolbar actions to copy or download raw proxy lines (all, working, or failed)—the same format you can paste under **Load Proxies**—or download a **CSV** with status, latency, exit IP, country, and error columns for spreadsheets.
 - 🔄 **Automatic Updates:** The app notifies you when a new version is available, so you're always up-to-date.
 - 💻 **Cross-Platform:** Works seamlessly on macOS, Windows, and Linux.
 - **🧠 Pro Mode:** Advanced diagnostics like DNS timing, TCP handshake duration, proxy auth time, and more. For power users and professionals.
@@ -66,7 +67,7 @@ _(Note: The version numbers in the filenames update with each new release. These
 > **Important Note for macOS Users:**
 > The first time you run the app, you will need to **right-click** the application icon and select **"Open"** from the context menu. In the security prompt that appears, click **"Open"** again. You only need to do this once.
 
-Once installed, simply paste your proxy list, configure your options, and click "Run Test"!
+Once installed, simply paste your proxy list, configure your options, and click "Run Test". When the run completes, use **Export** to copy or save results as text or CSV.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tauri-apps/plugin-clipboard-manager": "~2",
     "@tauri-apps/plugin-dialog": "^2.3.0",
+    "@tauri-apps/plugin-fs": "~2",
     "@tauri-apps/plugin-http": "~2",
     "@tauri-apps/plugin-opener": "~2",
     "@tauri-apps/plugin-os": "~2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -127,6 +127,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.1",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +959,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.9.1",
+ "block2 0.6.1",
+ "libc",
  "objc2 0.6.1",
 ]
 
@@ -950,6 +973,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -3584,6 +3616,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.1",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.1",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.1",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3795,6 +3852,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4510,6 +4573,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e5858cc7b455a73ab4ea2ebc08b5be33682c00ff1bf4cad5537d4fb62499d9"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.12",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-fs"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,9 +5004,11 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -5346,6 +5429,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -5508,6 +5593,7 @@ dependencies = [
  "cc",
  "downcast-rs",
  "rustix 1.0.8",
+ "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
@@ -5566,6 +5652,8 @@ version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
 dependencies = [
+ "dlib",
+ "log",
  "pkg-config",
 ]
 
@@ -6350,6 +6438,7 @@ dependencies = [
  "ordered-stream",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",
@@ -6487,6 +6576,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 0.7.12",
  "zvariant_derive",
  "zvariant_utils",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ tauri-plugin-shell = "2"
 tauri-plugin-http = "2"
 tauri-plugin-os = "2"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,19 @@
     "os:default",
     "process:default",
     "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text",
+    "dialog:default",
+    "fs:default",
+    {
+      "identifier": "fs:allow-write-text-file",
+      "allow": [
+        { "path": "$HOME/**" },
+        { "path": "$DOWNLOAD/**" },
+        { "path": "$DOCUMENT/**" },
+        { "path": "$DESKTOP/**" },
+        { "path": "$TEMP/**" }
+      ]
+    },
     {
       "identifier": "shell:allow-spawn",
       "allow": [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,8 @@
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_shell::init())

--- a/src/components/results/export-results-menu.tsx
+++ b/src/components/results/export-results-menu.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { motion } from "framer-motion";
+import { Download } from "lucide-react";
+import { toast } from "sonner";
+import { useProxyTesterStore } from "@/store/proxy";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { copyTextToClipboard } from "@/lib/clipboard-write";
+import { formatUnknownError } from "@/lib/format-error";
+import { saveTextWithPicker } from "@/lib/save-text-file";
+import {
+  filterByStatus,
+  scopeLabel,
+  toCsv,
+  toRawLines,
+  type ExportScope,
+} from "@/lib/export-tested-proxies";
+
+const COPY_SCOPES: ExportScope[] = ["all", "ok", "fail"];
+const TXT_SCOPES: ExportScope[] = ["all", "ok", "fail"];
+
+const MENU_WIDTH = 260;
+const MENU_GAP = 8;
+
+function scopeTitle(scope: ExportScope, action: "copy" | "download"): string {
+  const label = scopeLabel(scope);
+  if (action === "copy") {
+    return scope === "all" ? "Copy all" : `Copy ${label} only`;
+  }
+  return scope === "all" ? "Download .txt (all)" : `Download .txt (${label} only)`;
+}
+
+function exportFilename(scope: ExportScope, ext: "txt" | "csv"): string {
+  const d = new Date();
+  const date = d.toISOString().slice(0, 10);
+  const scopePart = scope === "all" ? "all" : scopeLabel(scope).replace(/\s+/g, "-");
+  return `proxy-export-${date}-${scopePart}.${ext}`;
+}
+
+type MenuCoords = { top: number; left: number };
+
+export default function ExportResultsMenu() {
+  const { testedProxies, testStatus } = useProxyTesterStore();
+  const [open, setOpen] = useState(false);
+  const [menuCoords, setMenuCoords] = useState<MenuCoords | null>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const blocked =
+    testStatus === "testing" || testStatus === "stopping" || testedProxies.length === 0;
+
+  useEffect(() => {
+    if (blocked) setOpen(false);
+  }, [blocked]);
+
+  const updateMenuPosition = useCallback(() => {
+    const trigger = wrapRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    let left = rect.right - MENU_WIDTH;
+    left = Math.max(MENU_GAP, Math.min(left, window.innerWidth - MENU_WIDTH - MENU_GAP));
+
+    const estimatedHeight = 360;
+    const spaceBelow = window.innerHeight - rect.bottom - MENU_GAP;
+    let top = rect.bottom + MENU_GAP;
+    if (spaceBelow < estimatedHeight && rect.top > estimatedHeight * 0.45) {
+      top = rect.top - estimatedHeight - MENU_GAP;
+    }
+    top = Math.max(MENU_GAP, Math.min(top, window.innerHeight - estimatedHeight - MENU_GAP));
+
+    setMenuCoords({ top, left });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open || blocked) {
+      setMenuCoords(null);
+      return;
+    }
+    updateMenuPosition();
+  }, [open, blocked, updateMenuPosition]);
+
+  useEffect(() => {
+    if (!open || blocked) return;
+    const onScrollOrResize = () => updateMenuPosition();
+    window.addEventListener("resize", onScrollOrResize);
+    window.addEventListener("scroll", onScrollOrResize, true);
+    return () => {
+      window.removeEventListener("resize", onScrollOrResize);
+      window.removeEventListener("scroll", onScrollOrResize, true);
+    };
+  }, [open, blocked, updateMenuPosition]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (event: MouseEvent) => {
+      const t = event.target as Node;
+      if (wrapRef.current?.contains(t)) return;
+      if (menuRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const handleCopy = async (scope: ExportScope) => {
+    const list = filterByStatus(testedProxies, scope);
+    const text = toRawLines(list);
+    if (!text) {
+      toast.error("Nothing to copy", {
+        description: `No ${scopeLabel(scope)} proxies in the results.`,
+      });
+      return;
+    }
+    try {
+      await copyTextToClipboard(text);
+      toast.success(`Copied ${list.length} ${list.length === 1 ? "proxy" : "proxies"}`, {
+        description: `${scopeLabel(scope)} — raw lines`,
+      });
+      setOpen(false);
+    } catch {
+      toast.error("Could not copy", {
+        description: "Clipboard access was blocked or unavailable.",
+      });
+    }
+  };
+
+  const handleDownloadTxt = async (scope: ExportScope) => {
+    const list = filterByStatus(testedProxies, scope);
+    const text = toRawLines(list);
+    if (!text) {
+      toast.error("Nothing to download", {
+        description: `No ${scopeLabel(scope)} proxies in the results.`,
+      });
+      return;
+    }
+    const filename = exportFilename(scope, "txt");
+    try {
+      const outcome = await saveTextWithPicker(filename, text, "txt");
+      if (outcome === "cancelled") return;
+      toast.success(`Saved ${list.length} ${list.length === 1 ? "proxy" : "proxies"}`, {
+        description: filename,
+      });
+      setOpen(false);
+    } catch (err) {
+      console.error(err);
+      toast.error("Could not save file", {
+        description: formatUnknownError(err),
+      });
+    }
+  };
+
+  const handleDownloadCsv = async () => {
+    const list = filterByStatus(testedProxies, "all");
+    const csv = toCsv(list);
+    const filename = exportFilename("all", "csv");
+    try {
+      const outcome = await saveTextWithPicker(filename, csv, "csv");
+      if (outcome === "cancelled") return;
+      toast.success("CSV saved", {
+        description: filename,
+      });
+      setOpen(false);
+    } catch (err) {
+      console.error(err);
+      toast.error("Could not save file", {
+        description: formatUnknownError(err),
+      });
+    }
+  };
+
+  const disabledReason =
+    testedProxies.length === 0
+      ? "Run a test first to export results"
+      : testStatus === "testing" || testStatus === "stopping"
+        ? "Wait until the test finishes"
+        : undefined;
+
+  const triggerButton = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="lg"
+      disabled={blocked}
+      onClick={() => !blocked && setOpen((v) => !v)}
+      className={
+        blocked ? "text-gray-500" : "text-gray-400 hover:text-white"
+      }
+      aria-expanded={open}
+      aria-haspopup="menu"
+    >
+      <Download className="w-4 h-4 mr-2" />
+      Export
+    </Button>
+  );
+
+  const menuPanel =
+    open &&
+    !blocked &&
+    menuCoords &&
+    typeof document !== "undefined" &&
+    createPortal(
+      <div
+        ref={menuRef}
+        role="menu"
+        style={{
+          position: "fixed",
+          top: menuCoords.top,
+          left: menuCoords.left,
+          width: MENU_WIDTH,
+          zIndex: 200,
+        }}
+        className="max-h-[min(70vh,calc(100vh-24px))] overflow-y-auto rounded-2xl border border-white/20 bg-[rgba(255,255,255,0.01)] shadow-lg backdrop-blur-3xl"
+      >
+        <motion.div
+          initial={{ opacity: 0, scale: 0.96, y: -6 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          transition={{ type: "spring", stiffness: 400, damping: 28 }}
+        >
+          <div className="border-b border-white/10 px-3 py-3">
+            <div className="flex items-center gap-2">
+              <Download className="text-accent size-5 shrink-0" />
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-white">Export results</p>
+                <p className="text-xs text-gray-400 leading-snug">
+                  Raw lines match Load Proxies / paste import
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="px-1 py-2">
+            <p className="px-3 pb-1 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+              Copy
+            </p>
+            {COPY_SCOPES.map((scope) => (
+              <button
+                key={`copy-${scope}`}
+                type="button"
+                role="menuitem"
+                className="w-full rounded-lg px-3 py-2 text-left text-sm text-white/90 transition-colors hover:bg-white/5"
+                onClick={() => void handleCopy(scope)}
+              >
+                {scopeTitle(scope, "copy")}
+              </button>
+            ))}
+
+            <div className="my-2 border-t border-white/10" />
+
+            <p className="px-3 pb-1 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+              Download .txt
+            </p>
+            {TXT_SCOPES.map((scope) => (
+              <button
+                key={`txt-${scope}`}
+                type="button"
+                role="menuitem"
+                className="w-full rounded-lg px-3 py-2 text-left text-sm text-white/90 transition-colors hover:bg-white/5"
+                onClick={() => handleDownloadTxt(scope)}
+              >
+                {scopeTitle(scope, "download")}
+              </button>
+            ))}
+
+            <div className="my-2 border-t border-white/10" />
+
+            <p className="px-3 pb-1 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+              Spreadsheet
+            </p>
+            <button
+              type="button"
+              role="menuitem"
+              className="w-full rounded-lg px-3 py-2 text-left text-sm text-white/90 transition-colors hover:bg-white/5"
+              onClick={handleDownloadCsv}
+            >
+              Download CSV (all columns)
+            </button>
+          </div>
+        </motion.div>
+      </div>,
+      document.body
+    );
+
+  return (
+    <div className="relative" ref={wrapRef}>
+      {blocked && disabledReason ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">{triggerButton}</span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{disabledReason}</p>
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        triggerButton
+      )}
+
+      {menuPanel}
+    </div>
+  );
+}

--- a/src/components/results/export-results-menu.tsx
+++ b/src/components/results/export-results-menu.tsx
@@ -4,12 +4,17 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
+  type ComponentType,
+  type ReactNode,
+  type RefObject,
 } from "react";
 import { createPortal } from "react-dom";
-import { motion } from "framer-motion";
-import { Download } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+import type { Proxy } from "@/types";
+import { Clipboard, Download, FileSpreadsheet, FileText } from "lucide-react";
 import { toast } from "sonner";
 import { useProxyTesterStore } from "@/store/proxy";
 import { Button } from "@/components/ui/button";
@@ -28,92 +33,137 @@ import {
   toRawLines,
   type ExportScope,
 } from "@/lib/export-tested-proxies";
+import { cn } from "@/lib/utils";
 
-const COPY_SCOPES: ExportScope[] = ["all", "ok", "fail"];
-const TXT_SCOPES: ExportScope[] = ["all", "ok", "fail"];
-
-const MENU_WIDTH = 260;
+const EXPORT_SCOPES: ExportScope[] = ["all", "ok", "fail"];
 const MENU_GAP = 8;
 
-function scopeTitle(scope: ExportScope, action: "copy" | "download"): string {
-  const label = scopeLabel(scope);
-  if (action === "copy") {
-    return scope === "all" ? "Copy all" : `Copy ${label} only`;
-  }
-  return scope === "all" ? "Download .txt (all)" : `Download .txt (${label} only)`;
-}
+type ExportActionKind = "copy" | "txt";
 
 function exportFilename(scope: ExportScope, ext: "txt" | "csv"): string {
-  const d = new Date();
-  const date = d.toISOString().slice(0, 10);
-  const scopePart = scope === "all" ? "all" : scopeLabel(scope).replace(/\s+/g, "-");
+  const date = new Date().toISOString().slice(0, 10);
+  const scopePart =
+    scope === "all" ? "all" : scopeLabel(scope).replace(/\s+/g, "-");
   return `proxy-export-${date}-${scopePart}.${ext}`;
 }
 
-type MenuCoords = { top: number; left: number };
+function scopeCounts(proxies: Proxy[]) {
+  return {
+    all: proxies.length,
+    ok: filterByStatus(proxies, "ok").length,
+    fail: filterByStatus(proxies, "fail").length,
+  } satisfies Record<ExportScope, number>;
+}
+
+function scopeName(scope: ExportScope): string {
+  if (scope === "all") return "All";
+  return scopeLabel(scope);
+}
+
+function ExportGroup({
+  icon: Icon,
+  label,
+  children,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="py-0.5">
+      <div className="flex items-center gap-2 px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-text-muted">
+        <Icon className="size-3.5 shrink-0 text-accent" />
+        {label}
+      </div>
+      <div className="flex flex-col">{children}</div>
+    </div>
+  );
+}
+
+function ScopeRow({
+  label,
+  count,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled || count === 0}
+      onClick={() => void onClick()}
+      className={cn(
+        "flex w-full cursor-pointer items-center rounded-md py-1 pl-6 pr-2 text-sm",
+        "text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary",
+        "disabled:pointer-events-none disabled:opacity-40",
+      )}
+    >
+      <span className="flex-1 text-left capitalize">{label}</span>
+      <span className="font-mono text-xs tabular-nums text-text-muted">
+        {count}
+      </span>
+    </button>
+  );
+}
+
+function useAnchoredPosition(
+  open: boolean,
+  anchorRef: RefObject<HTMLDivElement | null>,
+) {
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+
+  const update = useCallback(() => {
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    setPosition({
+      top: rect.bottom + MENU_GAP,
+      left: rect.left,
+    });
+  }, [anchorRef]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [open, update]);
+
+  return position;
+}
 
 export default function ExportResultsMenu() {
   const { testedProxies, testStatus } = useProxyTesterStore();
   const [open, setOpen] = useState(false);
-  const [menuCoords, setMenuCoords] = useState<MenuCoords | null>(null);
-  const wrapRef = useRef<HTMLDivElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const position = useAnchoredPosition(open, anchorRef);
 
   const blocked =
-    testStatus === "testing" || testStatus === "stopping" || testedProxies.length === 0;
+    testStatus === "testing" ||
+    testStatus === "stopping" ||
+    testedProxies.length === 0;
+
+  const counts = useMemo(() => scopeCounts(testedProxies), [testedProxies]);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (blocked) setOpen(false);
   }, [blocked]);
-
-  const updateMenuPosition = useCallback(() => {
-    const trigger = wrapRef.current;
-    if (!trigger) return;
-    const rect = trigger.getBoundingClientRect();
-    let left = rect.right - MENU_WIDTH;
-    left = Math.max(MENU_GAP, Math.min(left, window.innerWidth - MENU_WIDTH - MENU_GAP));
-
-    const estimatedHeight = 360;
-    const spaceBelow = window.innerHeight - rect.bottom - MENU_GAP;
-    let top = rect.bottom + MENU_GAP;
-    if (spaceBelow < estimatedHeight && rect.top > estimatedHeight * 0.45) {
-      top = rect.top - estimatedHeight - MENU_GAP;
-    }
-    top = Math.max(MENU_GAP, Math.min(top, window.innerHeight - estimatedHeight - MENU_GAP));
-
-    setMenuCoords({ top, left });
-  }, []);
-
-  useLayoutEffect(() => {
-    if (!open || blocked) {
-      setMenuCoords(null);
-      return;
-    }
-    updateMenuPosition();
-  }, [open, blocked, updateMenuPosition]);
-
-  useEffect(() => {
-    if (!open || blocked) return;
-    const onScrollOrResize = () => updateMenuPosition();
-    window.addEventListener("resize", onScrollOrResize);
-    window.addEventListener("scroll", onScrollOrResize, true);
-    return () => {
-      window.removeEventListener("resize", onScrollOrResize);
-      window.removeEventListener("scroll", onScrollOrResize, true);
-    };
-  }, [open, blocked, updateMenuPosition]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (event: MouseEvent) => {
-      const t = event.target as Node;
-      if (wrapRef.current?.contains(t)) return;
-      if (menuRef.current?.contains(t)) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", onDown);
-    return () => document.removeEventListener("mousedown", onDown);
-  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -124,25 +174,31 @@ export default function ExportResultsMenu() {
     return () => document.removeEventListener("keydown", onKey);
   }, [open]);
 
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (anchorRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [open]);
+
   const handleCopy = async (scope: ExportScope) => {
     const list = filterByStatus(testedProxies, scope);
     const text = toRawLines(list);
     if (!text) {
-      toast.error("Nothing to copy", {
-        description: `No ${scopeLabel(scope)} proxies in the results.`,
-      });
+      toast.error("Nothing to copy");
       return;
     }
     try {
       await copyTextToClipboard(text);
-      toast.success(`Copied ${list.length} ${list.length === 1 ? "proxy" : "proxies"}`, {
-        description: `${scopeLabel(scope)} — raw lines`,
-      });
+      toast.success(`Copied ${list.length}`);
       setOpen(false);
     } catch {
-      toast.error("Could not copy", {
-        description: "Clipboard access was blocked or unavailable.",
-      });
+      toast.error("Copy failed");
     }
   };
 
@@ -150,24 +206,18 @@ export default function ExportResultsMenu() {
     const list = filterByStatus(testedProxies, scope);
     const text = toRawLines(list);
     if (!text) {
-      toast.error("Nothing to download", {
-        description: `No ${scopeLabel(scope)} proxies in the results.`,
-      });
+      toast.error("Nothing to save");
       return;
     }
     const filename = exportFilename(scope, "txt");
     try {
       const outcome = await saveTextWithPicker(filename, text, "txt");
       if (outcome === "cancelled") return;
-      toast.success(`Saved ${list.length} ${list.length === 1 ? "proxy" : "proxies"}`, {
-        description: filename,
-      });
+      toast.success(`Saved ${list.length}`);
       setOpen(false);
     } catch (err) {
       console.error(err);
-      toast.error("Could not save file", {
-        description: formatUnknownError(err),
-      });
+      toast.error("Save failed", { description: formatUnknownError(err) });
     }
   };
 
@@ -178,23 +228,41 @@ export default function ExportResultsMenu() {
     try {
       const outcome = await saveTextWithPicker(filename, csv, "csv");
       if (outcome === "cancelled") return;
-      toast.success("CSV saved", {
-        description: filename,
-      });
+      toast.success("CSV saved");
       setOpen(false);
     } catch (err) {
       console.error(err);
-      toast.error("Could not save file", {
-        description: formatUnknownError(err),
-      });
+      toast.error("Save failed", { description: formatUnknownError(err) });
     }
+  };
+
+  const runExport = (kind: ExportActionKind, scope: ExportScope) => {
+    if (busy) return;
+    setBusy(true);
+    const done = () => setBusy(false);
+    if (kind === "copy") {
+      void handleCopy(scope).finally(done);
+    } else {
+      void handleDownloadTxt(scope).finally(done);
+    }
+  };
+
+  const runCsv = () => {
+    if (busy) return;
+    setBusy(true);
+    void handleDownloadCsv().finally(() => setBusy(false));
+  };
+
+  const toggleOpen = () => {
+    if (blocked) return;
+    setOpen((v) => !v);
   };
 
   const disabledReason =
     testedProxies.length === 0
-      ? "Run a test first to export results"
+      ? "Run a test first"
       : testStatus === "testing" || testStatus === "stopping"
-        ? "Wait until the test finishes"
+        ? "Wait for test to finish"
         : undefined;
 
   const triggerButton = (
@@ -203,121 +271,101 @@ export default function ExportResultsMenu() {
       variant="ghost"
       size="lg"
       disabled={blocked}
-      onClick={() => !blocked && setOpen((v) => !v)}
-      className={
-        blocked ? "text-gray-500" : "text-gray-400 hover:text-white"
-      }
       aria-expanded={open}
       aria-haspopup="menu"
+      onClick={toggleOpen}
+      className={cn(
+        blocked ? "text-gray-500" : "text-gray-400 hover:text-white",
+        open && !blocked && "text-white",
+      )}
     >
       <Download className="w-4 h-4 mr-2" />
       Export
+      {!blocked && counts.all > 0 && (
+        <span className="ml-1 font-mono text-xs tabular-nums text-text-muted">
+          {counts.all}
+        </span>
+      )}
     </Button>
   );
 
-  const menuPanel =
-    open &&
-    !blocked &&
-    menuCoords &&
-    typeof document !== "undefined" &&
-    createPortal(
-      <div
-        ref={menuRef}
-        role="menu"
-        style={{
-          position: "fixed",
-          top: menuCoords.top,
-          left: menuCoords.left,
-          width: MENU_WIDTH,
-          zIndex: 200,
-        }}
-        className="max-h-[min(70vh,calc(100vh-24px))] overflow-y-auto rounded-2xl border border-white/20 bg-[rgba(255,255,255,0.01)] shadow-lg backdrop-blur-3xl"
-      >
+  const menu = (
+    <AnimatePresence>
+      {open && !blocked && (
         <motion.div
-          initial={{ opacity: 0, scale: 0.96, y: -6 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          transition={{ type: "spring", stiffness: 400, damping: 28 }}
+          ref={menuRef}
+          role="menu"
+          initial={{ opacity: 0, scale: 0.96 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.96 }}
+          transition={{ duration: 0.15 }}
+          style={{ top: position.top, left: position.left }}
+          className={cn(
+            "fixed z-50 w-56 origin-top-left overflow-hidden rounded-2xl",
+            "border border-white/20 bg-[rgba(255,255,255,0.01)] shadow-xl backdrop-blur-3xl",
+          )}
         >
-          <div className="border-b border-white/10 px-3 py-3">
-            <div className="flex items-center gap-2">
-              <Download className="text-accent size-5 shrink-0" />
-              <div className="min-w-0">
-                <p className="text-sm font-semibold text-white">Export results</p>
-                <p className="text-xs text-gray-400 leading-snug">
-                  Raw lines match Load Proxies / paste import
-                </p>
-              </div>
-            </div>
-          </div>
+          <div className="max-h-[min(70vh,24rem)] overflow-y-auto p-1.5 custom-scrollbar">
+            <ExportGroup icon={Clipboard} label="Copy">
+              {EXPORT_SCOPES.map((scope) => (
+                <ScopeRow
+                  key={`copy-${scope}`}
+                  label={scopeName(scope)}
+                  count={counts[scope]}
+                  disabled={busy}
+                  onClick={() => runExport("copy", scope)}
+                />
+              ))}
+            </ExportGroup>
 
-          <div className="px-1 py-2">
-            <p className="px-3 pb-1 text-[10px] font-medium uppercase tracking-wider text-gray-500">
-              Copy
-            </p>
-            {COPY_SCOPES.map((scope) => (
-              <button
-                key={`copy-${scope}`}
-                type="button"
-                role="menuitem"
-                className="w-full rounded-lg px-3 py-2 text-left text-sm text-white/90 transition-colors hover:bg-white/5"
-                onClick={() => void handleCopy(scope)}
-              >
-                {scopeTitle(scope, "copy")}
-              </button>
-            ))}
+            <div className="my-1 border-t border-white/10" role="separator" />
 
-            <div className="my-2 border-t border-white/10" />
+            <ExportGroup icon={FileText} label="Save as TXT">
+              {EXPORT_SCOPES.map((scope) => (
+                <ScopeRow
+                  key={`txt-${scope}`}
+                  label={scopeName(scope)}
+                  count={counts[scope]}
+                  disabled={busy}
+                  onClick={() => runExport("txt", scope)}
+                />
+              ))}
+            </ExportGroup>
 
-            <p className="px-3 pb-1 text-[10px] font-medium uppercase tracking-wider text-gray-500">
-              Download .txt
-            </p>
-            {TXT_SCOPES.map((scope) => (
-              <button
-                key={`txt-${scope}`}
-                type="button"
-                role="menuitem"
-                className="w-full rounded-lg px-3 py-2 text-left text-sm text-white/90 transition-colors hover:bg-white/5"
-                onClick={() => handleDownloadTxt(scope)}
-              >
-                {scopeTitle(scope, "download")}
-              </button>
-            ))}
+            <div className="my-1 border-t border-white/10" role="separator" />
 
-            <div className="my-2 border-t border-white/10" />
-
-            <p className="px-3 pb-1 text-[10px] font-medium uppercase tracking-wider text-gray-500">
-              Spreadsheet
-            </p>
-            <button
-              type="button"
-              role="menuitem"
-              className="w-full rounded-lg px-3 py-2 text-left text-sm text-white/90 transition-colors hover:bg-white/5"
-              onClick={handleDownloadCsv}
-            >
-              Download CSV (all columns)
-            </button>
+            <ExportGroup icon={FileSpreadsheet} label="CSV">
+              <ScopeRow
+                label="Full export"
+                count={counts.all}
+                disabled={busy}
+                onClick={runCsv}
+              />
+            </ExportGroup>
           </div>
         </motion.div>
-      </div>,
-      document.body
-    );
+      )}
+    </AnimatePresence>
+  );
 
   return (
-    <div className="relative" ref={wrapRef}>
-      {blocked && disabledReason ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">{triggerButton}</span>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>{disabledReason}</p>
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        triggerButton
-      )}
+    <>
+      <div ref={anchorRef} className="relative">
+        {blocked && disabledReason ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">{triggerButton}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{disabledReason}</p>
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          triggerButton
+        )}
+      </div>
 
-      {menuPanel}
-    </div>
+      {mounted ? createPortal(menu, document.body) : null}
+    </>
   );
 }

--- a/src/components/results/toolbar.tsx
+++ b/src/components/results/toolbar.tsx
@@ -25,6 +25,7 @@ import { motion } from "framer-motion";
 import { useMemo, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { isTauri } from "@tauri-apps/api/core";
+import ExportResultsMenu from "@/components/results/export-results-menu";
 
 export default function ProxyToolbar() {
   const { getUrl, fetch } = useApi();
@@ -413,6 +414,8 @@ export default function ProxyToolbar() {
             <Trash2 className="w-4 h-4 mr-2" />
             Clear
           </Button>
+
+          <ExportResultsMenu />
 
           {testStatus === "testing" ? (
             <Button

--- a/src/lib/clipboard-write.ts
+++ b/src/lib/clipboard-write.ts
@@ -1,0 +1,15 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { writeText as tauriWriteText } from "@tauri-apps/plugin-clipboard-manager";
+
+/**
+ * Writes text to the system clipboard. In the Tauri shell, uses the native
+ * clipboard plugin so large proxy lists behave reliably.
+ */
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (!text) return;
+  if (isTauri()) {
+    await tauriWriteText(text);
+  } else {
+    await navigator.clipboard.writeText(text);
+  }
+}

--- a/src/lib/export-tested-proxies.ts
+++ b/src/lib/export-tested-proxies.ts
@@ -1,0 +1,107 @@
+/**
+ * Helpers for exporting tested proxy results to text/CSV.
+ *
+ * **Raw lines** — one `Proxy.raw` per line, suitable for pasting back into the app.
+ *
+ * To save files to disk, use `saveTextWithPicker` from `@/lib/save-text-file`
+ * (Tauri’s webview often ignores blob + programmatic download; the save helper uses a native dialog there).
+ *
+ * **CSV columns** (header row is always present):
+ * - `raw` — original input string
+ * - `formatted` — normalized display string
+ * - `protocol` — detected protocol
+ * - `status` — `ok` | `fail` | `unknown`
+ * - `latency` — milliseconds when measured (empty if not applicable)
+ * - `exit_ip` — exit IP from simple geo lookup when present
+ * - `country` — country name from simple data when present
+ * - `error_code` — error code when failed
+ * - `error_message` — error message when failed
+ */
+
+import type { Proxy } from "@/types";
+
+/** Which tested rows to include when exporting (all, or only successes / failures). */
+export type ExportScope = "all" | "ok" | "fail";
+
+/**
+ * Filters proxies for export. Uses `status` only; `unknown` is included only when scope is `all`.
+ */
+export function filterByStatus(
+  proxies: Proxy[],
+  scope: ExportScope
+): Proxy[] {
+  if (scope === "all") return proxies;
+  return proxies.filter((p) => p.status === scope);
+}
+
+/**
+ * One `raw` proxy string per line; use for TXT paste/import round-trips.
+ */
+export function toRawLines(proxies: Proxy[]): string {
+  return proxies.map((p) => p.raw).join("\n");
+}
+
+function csvCell(value: string | number | undefined | null): string {
+  if (value === undefined || value === null) return "";
+  const s = String(value);
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+export type ToCsvOptions = {
+  /** ISO timestamp added as a comment in the first line (optional, for traceability). */
+  includeGeneratedComment?: boolean;
+};
+
+/**
+ * Builds a CSV document with a fixed header row. Empty cells when data is missing.
+ */
+export function toCsv(proxies: Proxy[], options?: ToCsvOptions): string {
+  const header = [
+    "raw",
+    "formatted",
+    "protocol",
+    "status",
+    "latency",
+    "exit_ip",
+    "country",
+    "error_code",
+    "error_message",
+  ];
+
+  const rows: string[][] = [header];
+
+  for (const p of proxies) {
+    rows.push([
+      csvCell(p.raw),
+      csvCell(p.formatted),
+      csvCell(p.protocol),
+      csvCell(p.status),
+      csvCell(p.latency !== undefined ? p.latency : ""),
+      csvCell(p.simpleData?.ip ?? ""),
+      csvCell(p.simpleData?.country ?? ""),
+      csvCell(p.error?.code ?? ""),
+      csvCell(p.error?.message ?? ""),
+    ]);
+  }
+
+  const body = rows.map((line) => line.join(",")).join("\r\n");
+  if (options?.includeGeneratedComment) {
+    return `# generated ${new Date().toISOString()}\r\n${body}`;
+  }
+  return body;
+}
+
+/** @internal — narrow status for labels in UI */
+export function scopeLabel(scope: ExportScope): string {
+  switch (scope) {
+    case "all":
+      return "all";
+    case "ok":
+      return "working";
+    case "fail":
+      return "failed";
+  }
+}

--- a/src/lib/format-error.ts
+++ b/src/lib/format-error.ts
@@ -1,0 +1,10 @@
+/** Best-effort message from Tauri invoke / plugin errors (not always `Error`). */
+export function formatUnknownError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  if (err && typeof err === "object" && "message" in err) {
+    const m = (err as { message: unknown }).message;
+    if (typeof m === "string") return m;
+  }
+  return "Unknown error";
+}

--- a/src/lib/save-text-file.ts
+++ b/src/lib/save-text-file.ts
@@ -1,0 +1,55 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+
+export type SaveTextOutcome = "saved" | "cancelled";
+
+/**
+ * Tauri’s webview does not reliably honor programmatic `<a download>` + blob URLs.
+ * On desktop we open a native Save dialog and write via the fs plugin; in the
+ * browser we keep the anchor + blob approach.
+ */
+export async function saveTextWithPicker(
+  suggestedFilename: string,
+  contents: string,
+  kind: "txt" | "csv"
+): Promise<SaveTextOutcome> {
+  if (isTauri()) {
+    const filters =
+      kind === "csv"
+        ? [{ name: "CSV", extensions: ["csv"] as string[] }]
+        : [{ name: "Text", extensions: ["txt"] as string[] }];
+
+    const path = await save({
+      defaultPath: suggestedFilename,
+      filters,
+    });
+
+    if (path === null) return "cancelled";
+
+    await writeTextFile(path, contents);
+    return "saved";
+  }
+
+  const mimeType =
+    kind === "csv" ? "text/csv;charset=utf-8" : "text/plain;charset=utf-8";
+  triggerBrowserDownload(suggestedFilename, contents, mimeType);
+  return "saved";
+}
+
+function triggerBrowserDownload(
+  filename: string,
+  contents: string,
+  mimeType: string
+): void {
+  const blob = new Blob([contents], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,6 +1021,11 @@
     postcss "^8.4.41"
     tailwindcss "4.1.11"
 
+"@tauri-apps/api@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/api/-/api-2.11.0.tgz#00fb69996010178a5153798d4a84f6fe3a1e1182"
+  integrity sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==
+
 "@tauri-apps/api@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@tauri-apps/api/-/api-2.6.0.tgz"
@@ -1111,6 +1116,13 @@
   integrity sha512-ylSBvYYShpGlKKh732ZuaHyJ5Ie1JR71QCXewCtsRLqGdc8Is4xWdz6t43rzXyvkItM9syNPMvFVcvjgEy+/GA==
   dependencies:
     "@tauri-apps/api" "^2.6.0"
+
+"@tauri-apps/plugin-fs@~2":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/plugin-fs/-/plugin-fs-2.5.1.tgz#e1b8643d41c74251699fcdecc800877d18a4a6fc"
+  integrity sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==
+  dependencies:
+    "@tauri-apps/api" "^2.11.0"
 
 "@tauri-apps/plugin-http@~2":
   version "2.5.1"


### PR DESCRIPTION
<img width="906" height="516" alt="image" src="https://github.com/user-attachments/assets/6f35356c-3851-4849-8c1f-7ba01afe4358" />

Adds export functionality for tested proxy results.

Users can now:

- Export working proxies

- Copy successful proxies to clipboard

- Save results as a file for large-scale proxy testing workflows

## Changes

- Added export button to proxy results table

- Added filesystem + dialog support

- Implemented export formatting logic

Closes #8